### PR TITLE
fix: update docker-compose SSL_EMAIL env var handling for certbot

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,7 +46,8 @@ services:
       - ./certbot/www:/var/www/certbot
     env_file:
       - env.production
-    command: sh -c "certonly --webroot --webroot-path=/var/www/certbot --email $SSL_EMAIL --agree-tos --no-eff-email -d thesignalcallers.com -d www.thesignalcallers.com"
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["certbot certonly --webroot --webroot-path=/var/www/certbot --email $$SSL_EMAIL --agree-tos --no-eff-email -d thesignalcallers.com -d www.thesignalcallers.com"]
     depends_on:
       - nginx
     networks:


### PR DESCRIPTION
## Summary by Sourcery

Fix SSL_EMAIL environment variable handling in the production Docker Compose setup

Bug Fixes:
- Correct SSL_EMAIL interpolation in the certbot service command

Deployment:
- Remove Docker Compose version and redundant environment block to rely on env_file
- Wrap certbot command in sh -c to enable proper environment variable expansion