### PR TITLE
fix: configure nginx SSL for OpenSSL 1.0.2k compatibility - remove TL…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -45,16 +45,15 @@ http {
     # HTTPS server
     server {
         listen 443 ssl;
-        http2 on;
         server_name thesignalcallers.com www.thesignalcallers.com;
 
         # SSL configuration
         ssl_certificate /etc/letsencrypt/live/thesignalcallers.com/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/thesignalcallers.com/privkey.pem;
 
-        # SSL security settings
-        ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK;
+        # SSL security settings - compatible with OpenSSL 1.0.2k
+        ssl_protocols TLSv1.2;
+        ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
         ssl_prefer_server_ciphers off;
         ssl_session_cache shared:SSL:10m;
         ssl_session_timeout 10m;

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,10 @@
 # Nginx configuration for HTTPS termination
+#
+# SSL/TLS Configuration Notes:
+# - HTTP/2 enabled for improved performance with TLS 1.2
+# - TLS 1.3 disabled due to OpenSSL 1.0.2k compatibility requirements
+# - Using Mozilla "Intermediate" cipher profile for security vs compatibility balance
+# - TODO: Upgrade to OpenSSL 1.1.1+ to enable TLS 1.3 and improved security
 events {
     worker_connections 1024;
 }
@@ -44,7 +50,7 @@ http {
 
     # HTTPS server
     server {
-        listen 443 ssl;
+        listen 443 ssl http2;
         server_name thesignalcallers.com www.thesignalcallers.com;
 
         # SSL configuration
@@ -52,8 +58,13 @@ http {
         ssl_certificate_key /etc/letsencrypt/live/thesignalcallers.com/privkey.pem;
 
         # SSL security settings - compatible with OpenSSL 1.0.2k
+        # TODO: Upgrade OpenSSL to enable TLS 1.3 support for improved security
+        # Current limitation: Amazon Linux 2 ships with OpenSSL 1.0.2k (2017)
+        # Upgrade path: Consider migrating to Amazon Linux 2023 or updating OpenSSL
         ssl_protocols TLSv1.2;
-        ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
+        # Using Mozilla "Intermediate" cipher profile for OpenSSL 1.0.2k compatibility
+        # Reference: https://ssl-config.mozilla.org/#server=nginx&version=1.18.0&config=intermediate&openssl=1.0.2k&guideline=5.6
+        ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK;
         ssl_prefer_server_ciphers off;
         ssl_session_cache shared:SSL:10m;
         ssl_session_timeout 10m;


### PR DESCRIPTION
…S 1.3 and HTTP/2

## Summary by Sourcery

Adjust Nginx SSL configuration to maintain compatibility with OpenSSL 1.0.2k by removing unsupported features and narrowing the protocol and cipher selections

Deployment:
- Remove the http2 directive and drop TLSv1.3 support
- Restrict SSL protocols to TLSv1.2 and update cipher suites for OpenSSL 1.0.2k compatibility